### PR TITLE
Potential fix for code scanning alert no. 45: Bad HTML filtering regexp

### DIFF
--- a/tests/security/data-validation.security.test.ts
+++ b/tests/security/data-validation.security.test.ts
@@ -15,7 +15,7 @@ describe('Data Validation Security Tests', () => {
   // XSS Detection
   const detectXss = (input: string): boolean => {
     const xssPatterns = [
-      /<script[^>]*>.*?<\/script>/gi,
+      /<script[^>]*>.*?<\/script\b[^>]*>/gi,
       /<iframe[^>]*>.*?<\/iframe>/gi,
       /javascript:/gi,
       /on\w+\s*=/gi,


### PR DESCRIPTION
Potential fix for [https://github.com/lazylmf-ai/Easy-e-Invoice/security/code-scanning/45](https://github.com/lazylmf-ai/Easy-e-Invoice/security/code-scanning/45)

To fix the problem, the regular expression used to detect `<script>` tags should be updated to match closing tags that may contain extra spaces or attributes, such as `</script >` or `</script foo="bar">`. The best way to do this is to modify the regex so that the closing tag matches any characters after `</script` up to the next `>`, rather than strictly requiring `</script>`. Specifically, replace `</script>` with `<\/script\b[^>]*>`, which matches `</script` followed by optional whitespace or attributes, and then the closing `>`. This change should be made in the `xssPatterns` array on line 18 of `tests/security/data-validation.security.test.ts`. No new imports are needed, as this is a regex change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
